### PR TITLE
allow user-defined's entry's and exit's function to use object of state

### DIFF
--- a/src/model/Action.ts
+++ b/src/model/Action.ts
@@ -4,6 +4,7 @@
  * Licensed under the MIT and GPL v3 licences
  * http://www.steelbreeze.net/state.cs
  */
+
 module StateJS {
 	/**
 	 * Declaration for callbacks that provide state entry, state exit and transition behavior.
@@ -14,6 +15,6 @@ module StateJS {
 	 * @returns {any} Actions can return any value.
 	 */
 	export interface Action {
-		(message?: any, instance?: IInstance, history?: boolean): any;
+		(message?: any, instance?: IInstance, history?: boolean,state?:State): any;
 	}
 }

--- a/src/model/Behavior.ts
+++ b/src/model/Behavior.ts
@@ -66,8 +66,8 @@ module StateJS {
 		 * @param {IInstance} instance The state machine instance.
 		 * @param {boolean} history Internal use only
 		 */
-		invoke(message: any, instance: IInstance, history: boolean = false): void {
-			this.actions.forEach(action => action(message, instance, history));
+		invoke(message: any, instance: IInstance, history: boolean = false,state?:State): void {
+			this.actions.forEach(action => action(message, instance, history,state));
 		}
 	}
 }

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -308,8 +308,8 @@ module StateJS {
 			this.visitVertex(state, deepHistoryAbove);
 
 			// add the user defined behavior when entering and exiting states
-			this.behavior(state).leave.push(state.exitBehavior);
-			this.behavior(state).beginEnter.push(state.entryBehavior);
+			this.behavior(state).leave.push((message, instance) => state.exitBehavior.invoke(undefined, instance,undefined,state));
+			this.behavior(state).beginEnter.push((message, instance) => state.entryBehavior.invoke(undefined, instance,undefined,state));
 
 			// update the parent regions current state
 			this.behavior(state).beginEnter.push((message, instance) => {


### PR DESCRIPTION
i found the code in runtime.ts at line 263
```javascript
this.behavior(element).leave.push((message, instance) => console.log(instance + " leave " + element));
```
this is user-defined entry
```javascript
new statejs.State("state", model).exit(function (message, instance) {console.log(state) });
```
but print **undefined**

so，i do some changs.Now it will can use the code
